### PR TITLE
Strip .sublime-package from PKG_NAME to fix template resource path.

### DIFF
--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -16,6 +16,9 @@ import sys
 
 PKG_NAME = path.basename(path.dirname(path.dirname(__file__)))
 
+if PKG_NAME.endswith(".sublime-package"):
+	PKG_NAME = PKG_NAME[:len(PKG_NAME) - 16]
+
 log = logging.getLogger("RTags")
 
 


### PR DESCRIPTION
This fixes an issue that I have on Ubuntu 18.04 with Sublime Text 3.2.2, build 3211.

The first time I try to get a symbol's information, I get the following error. Note that the resource path contains `RTagsComplete.sublime-package`, when it should instead contain `RTagsComplete`.

```
RTags:DEBUG: 2019-10-10 13:42:27,365 settings.py::update_templates [Thread-4]: Templates update
RTags:DEBUG: 2019-10-10 13:42:27,365 settings.py::update_templates [Thread-4]: load_binary_resource of Packages/RTagsComplete.sublime-package/themes/Default/error_popup.html
exception calling callback for <Future at 0x7f0cc79efc50 state=finished returned tuple>
Traceback (most recent call last):
  File "./python3.3/concurrent/futures/_base.py", line 296, in _invoke_callbacks
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/rtags.py", line 159, in command_done
    self._action(out, **kwargs)
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/rtags.py", line 595, in _action
    info.Controller.action(self.view, row, col, out)
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/plugin/info.py", line 502, in action
    info)
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/plugin/settings.py", line 76, in template_as_html
    update_templates()
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/plugin/settings.py", line 61, in update_templates
    sublime.load_binary_resource(filepath).decode('utf-8')
  File "/opt/sublime_text/sublime.py", line 199, in load_binary_resource
    raise IOError("resource not found")
OSError: resource not found
```

Subsequent attempts to get a symbol's information result in a different error, because now the `templates` global isn't `None`, but it hasn't been populated, either. Hence `template_as_html()` returns `None`, so the `rendered` argument to `show_popup()` is `None` instead of a string.

```
exception calling callback for <Future at 0x7f0cc7a016d0 state=finished returned tuple>
Traceback (most recent call last):
  File "./python3.3/concurrent/futures/_base.py", line 296, in _invoke_callbacks
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/rtags.py", line 159, in command_done
    self._action(out, **kwargs)
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/rtags.py", line 595, in _action
    info.Controller.action(self.view, row, col, out)
  File "/home/tlo/.config/sublime-text-3/Installed Packages/RTagsComplete.sublime-package/plugin/info.py", line 528, in action
    on_navigate=on_navigate)
  File "/opt/sublime_text/sublime.py", line 1146, in show_popup
    on_navigate, on_hide)
TypeError: String required
```

I think that this is identical to this ticket, which was opened for RTags: https://github.com/Andersbakken/rtags/issues/1281

I don't know Python very well and I don't know Sublime Text at all, so there might be a more elegant solution.