### PR TITLE
defined a parameter responsible for socket path 

### DIFF
--- a/RTagsComplete.sublime-settings
+++ b/RTagsComplete.sublime-settings
@@ -2,6 +2,9 @@
   // Path to rc utility if not found in $PATH.
   "rc_path": "/usr/local/bin/rc",
 
+  // Path to a socket file
+  // "rdm_socket": "/tmp/rdm/rdm.socket",
+
   // Seconds for rc utility communication timeout default.
   "rc_timeout": 30,
 

--- a/plugin/jobs.py
+++ b/plugin/jobs.py
@@ -100,7 +100,11 @@ class RTagsJob():
         self.command_active = futures.Future()
 
     def prepare_command(self):
-        return [settings.get('rc_path')] + self.command_info
+        cmd = [settings.get('rc_path')]
+        if settings.get('rdm_socket'):
+            cmd.append('--socket-file')
+            cmd.append(settings.get('rdm_socket'))
+        return cmd + self.command_info
 
     def active(self):
         return self.p.done()

--- a/rtags.py
+++ b/rtags.py
@@ -710,6 +710,7 @@ def update_settings():
     # Initialize settings with their defaults.
     settings.get('rc_timeout', 0.5)
     settings.get('rc_path', "/usr/local/bin/rc")
+    settings.get('rdm_socket', "")
     settings.get('validation', False)
     settings.get('hover', False)
     settings.get('auto_reindex', False)
@@ -723,6 +724,7 @@ def update_settings():
 
     settings.add_on_change('rc_timeout')
     settings.add_on_change('rc_path')
+    settings.add_on_change('rdm_socket')
     settings.add_on_change('auto_complete')
 
     settings.add_on_change('results_key')


### PR DESCRIPTION
A convenient way to specify a socket's path for server/client communication
Personally, I have RDM as a daemon launched by systemd and with the socket-file at a specific place
I need to say to a client (rc) where this socket is located via parameters